### PR TITLE
hide E803 when match is already deleted

### DIFF
--- a/plugin/current_search_match.vim
+++ b/plugin/current_search_match.vim
@@ -20,11 +20,11 @@ function! s:delete_current_match()
   let winid = s:pos[3]
   if winbufnr(winid) == -1 | return | endif
   if has('patch-8.1.1084') || has('nvim-0.5.0')
-    call matchdelete(s:match, winid)
+    try | call matchdelete(s:match, winid) | catch /^Vim\%((\a\+)\)\=:E803:/ | endtry
   else
     let same_win = winid == win_getid()
     if !same_win | noautocmd call win_gotoid(winid) | endif
-    call matchdelete(s:match)
+    try | call matchdelete(s:match) | catch /^Vim\%((\a\+)\)\=:E803:/ | endtry
     if !same_win | noautocmd wincmd p | endif
   endif
 endfunction


### PR DESCRIPTION
When matches set by `vim-current-search-match` are deleted from outside the script, it results in an error `E830: ID not found`.

I think it's okay to just hide it.

Steps to reproduce:

- vim --clean -S current_search_match.vim -c ':set hlsearch'
- / pattern
- call clearmatch()
- start another search (or, if the cursor is still on the pattern, move it aside)